### PR TITLE
Fixed typo in Camera2D

### DIFF
--- a/src/raylib-cr/lib_raylib.cr
+++ b/src/raylib-cr/lib_raylib.cr
@@ -496,7 +496,7 @@ lib LibRaylib
   end
 
   struct Camera2D
-    offest : Vector2
+    offset : Vector2
     target : Vector2
     rotation : LibC::Float
     zoom : LibC::Float


### PR DESCRIPTION
`Camera2D.offest` -> `Camera2D.offset`, didn't find the same typo anywhere else.