### PR TITLE
Update install.ps1

### DIFF
--- a/rsrc/install-ga.ps1
+++ b/rsrc/install-ga.ps1
@@ -9,16 +9,16 @@ git clone https://github.com/raysan5/raylib
 cd raylib
 mkdir build
 cd build 
-cmake .. -DBUILD_SHARED_LIBS=ON
+cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build .
-copy raylib\Debug\raylib.lib ..\..\libs\raylib.lib
-copy raylib\Debug\raylib.dll ..\..\libs\raylib.dll
+copy raylib\Release\raylib.lib ..\..\libs\raylib.lib
+copy raylib\Release\raylib.dll ..\..\libs\raylib.dll
 cd ..\..
 
 git clone https://github.com/raysan5/raygui
 cd raygui
 copy src\raygui.h src\raygui.c
-cl /O2 /I../raylib/src/ /D_USRDLL /D_WINDLL /DRAYGUI_IMPLEMENTATION /DBUILD_LIBTYPE_SHARED src/raygui.c /LD /Feraygui.dll /link /LIBPATH ../raylib/build/raylib/Debug/raylib.lib /subsystem:windows /machine:x64
+cl /O2 /I../raylib/src/ /D_USRDLL /D_WINDLL /DRAYGUI_IMPLEMENTATION /DBUILD_LIBTYPE_SHARED src/raygui.c /LD /Feraygui.dll /link /LIBPATH ../raylib/build/raylib/Release/raylib.lib /subsystem:windows /machine:x64
 copy raygui.lib ..\libs\raygui.lib
 copy raygui.dll ..\libs\raygui.dll
 cd ..

--- a/rsrc/install.ps1
+++ b/rsrc/install.ps1
@@ -11,8 +11,8 @@ cd build
 cmake .. -DBUILD_SHARED_LIBS=ON
 cmake --build .
 mkdir C:\raylib
-copy raylib\Debug\raylib.lib C:\raylib\raylib.lib
-copy raylib\Debug\raylib.dll C:\raylib\raylib.dll
+copy raylib\Release\raylib.lib C:\raylib\raylib.lib
+copy raylib\Release\raylib.dll C:\raylib\raylib.dll
 cd ..\..
 
 git clone https://github.com/raysan5/raygui

--- a/rsrc/install.ps1
+++ b/rsrc/install.ps1
@@ -8,7 +8,7 @@ git clone https://github.com/raysan5/raylib
 cd raylib
 mkdir build
 cd build 
-cmake .. -DBUILD_SHARED_LIBS=ON
+cmake .. -DBUILD_SHARED_LIBS=ON -DRAYLIB_BUILD_MODE=RELEASE
 cmake --build .
 mkdir C:\raylib
 copy raylib\Release\raylib.lib C:\raylib\raylib.lib

--- a/rsrc/install.ps1
+++ b/rsrc/install.ps1
@@ -8,7 +8,7 @@ git clone https://github.com/raysan5/raylib
 cd raylib
 mkdir build
 cd build 
-cmake .. -DBUILD_SHARED_LIBS=ON -DRAYLIB_BUILD_MODE=RELEASE
+cmake .. -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build .
 mkdir C:\raylib
 copy raylib\Release\raylib.lib C:\raylib\raylib.lib


### PR DESCRIPTION
This will change the logic to use the Release .`dll`
This will avoid errors such as the following on fresh windows installs that do not have VS Debug libraries (non-dev machines)

![image](https://github.com/sol-vin/raylib-cr/assets/1631073/add3f33a-40a1-453f-944d-5db7b199b4f2)
![image](https://github.com/sol-vin/raylib-cr/assets/1631073/bc1119eb-4475-4a8f-9732-d66387d08d27)

It is still worth noting that vcruntime140.dll might be needed, but that's something that maybe is worth specifying in the README.

Without this change, to "ship" a game\app made with raylib you will need the following DLLs:
![image](https://github.com/sol-vin/raylib-cr/assets/1631073/fcf49175-a9ec-413e-9c5d-7f158cb80fc4)

(Note the `d` at the end which specifies Debug).

With this change all you need is raylib.dll, raygui.dll (if used) and the `vcruntime140.dll` unless it was already installed by another game.

There should also be a way to statically link those DLLs into the exe, but it might need more compiler foo
