### PR TITLE
Fixed MacOS install/build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These platforms are supported out of the box and are linked statically
 2. 64-bit Windows
 
 Weak/Broken support
-1. Mac OS
+1. MacOS
 
 Hopefully soon  
  - Raspberry PI
@@ -63,6 +63,20 @@ dependencies:
 ```
 6. Run `shards install`
 7. Get programming!
+
+### MacOS
+1. Run
+```
+sudo sh rsrc/native/mac/mac-raylib-install.sh
+```
+2. Add `raylib-cr` to your `shard.yml`:
+```yml
+dependencies:
+  raylib-cr:
+    github: sol-vin/raylib-cr
+```
+3. Run `shards install`
+4. Get programming!
 
 # Usage Example
 

--- a/rsrc/native/mac/mac-raylib-build.sh
+++ b/rsrc/native/mac/mac-raylib-build.sh
@@ -4,6 +4,7 @@ set -e
 
 cd $(dirname "$0")
 test -d raylib || git clone --depth 1 --branch 5.0 --recursive https://github.com/raysan5/raylib 
+cd raylib
 test -d build || mkdir build
 cd build
 cmake ..

--- a/rsrc/native/mac/mac-raylib-install.sh
+++ b/rsrc/native/mac/mac-raylib-install.sh
@@ -3,4 +3,5 @@
 set -e
 
 test -f $(dirname "$0")/raylib/build/raylib/libraylib.a || sh $(dirname "$0")/mac-raylib-build.sh
+test -d /usr/local/lib || mkdir /usr/local/lib
 sudo cp $(dirname "$0")/raylib/build/raylib/libraylib.a /usr/local/lib/libraylib.a


### PR DESCRIPTION
- updated `mac-raylib-install.sh` to create the `/usr/local/lib directory` if it doesn't already exist
- updated `mac-raylib-build.sh` to cd into the raylib repo root directory before creating the build sub-directory and running cmake and make
- Added installation instructions for MacOS to the readme