### PR TITLE
Support MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ dependencies:
 3. Run `shards install`
 4. Get programming!
 
-### Windows
+### Windows MSVC
 
 1. Follow the instructions at https://github.com/neatorobito/scoop-crystal to add the crystal-preview bucket to scoop
 2. Install crystal with `scoop install crystal`
@@ -63,6 +63,21 @@ dependencies:
 ```
 6. Run `shards install`
 7. Get programming!
+
+### Windows MSYS2
+
+1. Run
+```sh
+sh rsrc/native/msys2/install.sh
+```
+2. Add `raylib-cr` to your `shard.yml`:
+```yml
+dependencies:
+  raylib-cr:
+    github: sol-vin/raylib-cr
+```
+3. Run `shards install`
+4. Get programming!
 
 ### MacOS
 1. Run

--- a/rsrc/native/msys2/install.sh
+++ b/rsrc/native/msys2/install.sh
@@ -1,0 +1,18 @@
+# Compile miniaudio helpers
+cc -c -fPIC rsrc/miniaudiohelpers/miniaudiohelpers.c -o rsrc/miniaudiohelpers/miniaudiohelpers.o
+cc rsrc/miniaudiohelpers/miniaudiohelpers.o -shared -lm \
+  -o${MINGW_PREFIX}/bin/libminiaudiohelpers.dll \
+  -Wl,--out-implib=${MINGW_PREFIX}/lib/libminiaudiohelpers.dll.a
+rm rsrc/miniaudiohelpers/miniaudiohelpers.o
+
+# Install raylib
+pacman -Sy "${MINGW_PACKAGE_PREFIX:+${MINGW_PACKAGE_PREFIX}-}raylib" --needed --noconfirm
+
+# Compile raygui
+git clone --depth 1 --branch 4.0 https://github.com/raysan5/raygui
+mv raygui/src/raygui.h raygui/src/raygui.c
+cc -c -fPIC raygui/src/raygui.c -o raygui/raygui.o -DRAYGUI_IMPLEMENTATION
+cc raygui/raygui.o -shared -DRAYGUI_IMPLEMENTATION -lraylib -lm -lpthread \
+  -o${MINGW_PREFIX}/bin/libraygui.dll \
+  -Wl,--out-implib=${MINGW_PREFIX}/lib/libraygui.dll.a
+rm -rf raygui

--- a/rsrc/native/msys2/uninstall.sh
+++ b/rsrc/native/msys2/uninstall.sh
@@ -1,0 +1,5 @@
+rm -f \
+  ${MINGW_PREFIX}/bin/libraygui.dll \
+  ${MINGW_PREFIX}/lib/libraygui.dll.a \
+  ${MINGW_PREFIX}/bin/libminiaudiohelpers.dll \
+  ${MINGW_PREFIX}/lib/libminiaudiohelpers.dll.a


### PR DESCRIPTION
This is a quick demonstration of how custom libraries could be manually installed on MSYS2, newly supported in Crystal 1.15, using the appropriate [environment variables](https://github.com/msys2/MSYS2-packages/blob/master/filesystem/msystem). (The MSYS environment is handled differently but Crystal will probably never support that environment.)