### PR TITLE
install cmake and run ldconfig during ubuntu install

### DIFF
--- a/rsrc/native/ubuntu/install.sh
+++ b/rsrc/native/ubuntu/install.sh
@@ -7,7 +7,7 @@ sudo ln -s /usr/lib/libminiaudiohelpers.so /lib/miniaudiohelpers.so
 # Compile raylib
 git clone --depth 1 --branch 5.0 https://github.com/raysan5/raylib
 mkdir raylib/build
-sudo apt-get install libasound2-dev libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxinerama-dev
+sudo apt-get install cmake libasound2-dev libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxinerama-dev
 cmake raylib -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -B raylib/build 
 cmake --build raylib/build
 sudo make install -C raylib/build
@@ -24,3 +24,6 @@ sudo ln -s /usr/lib/libraygui.so /lib/raygui.so
 
 rm -rf raygui
 rm -rf raylib
+
+# Update shared libraries cache, making libraylib.so and libraygui.so available
+sudo ldconfig


### PR DESCRIPTION
Running `sh rsrc/native/ubuntu/install.sh` failed due to missing `cmake`:

    ~/raylib-cr (master) ✓ sh rsrc/native/ubuntu/install.sh
    ..
    rsrc/native/ubuntu/install.sh: 11: cmake: not found
    rsrc/native/ubuntu/install.sh: 12: cmake: not found

Installing `cmake` fixed the installation.

But then running programs using `raylib-cr` failed:

    ~/raytest (main) ✓ crystal run src/raytest.cr 
    /home/lasse/.cache/crystal/crystal-run-raytest.tmp: error while loading shared libraries: libraylib.so.450: cannot open shared object file: No such file or directory

( `raytest.cr` was a copy of the [usage example](https://github.com/bitmand/raylib-cr?tab=readme-ov-file#usage-example) )

Updating shared libraries cache fixed it:

    ~/raytest (main) ✓ ldconfig -p|grep raylib
    ~/raytest (main) ✓ sudo ldconfig
    ~/raytest (main) ✓ ldconfig -p|grep raylib
    libraylib.so.450 (libc6,x86-64) => /usr/local/lib/libraylib.so.450
    libraylib.so (libc6,x86-64) => /usr/local/lib/libraylib.so

And then I got a nice Hello World window:

    ~/raytest (main) ✓ crystal run src/raytest.cr
    INFO: Initializing raylib 5.0
    INFO: Platform backend: DESKTOP (GLFW)
    INFO: Supported raylib modules:
    ...

( on Ubuntu 25.04 Plucky Puffin )