### PR TITLE
Add platform-specific compilation for miniaudio sizes

### DIFF
--- a/src/raylib-cr/miniaudio_fix/ma_sizes.cr
+++ b/src/raylib-cr/miniaudio_fix/ma_sizes.cr
@@ -14,45 +14,45 @@ def get_miniaudio_sizes
   # Path to the size-check C program
   c_file = "#{__DIR__}/../../../rsrc/miniaudiohelpers/miniaudio-size-check.c"
 
-  # Platform-specific compilation and execution
-  {% if flag?(:win32) %}
-    # Windows: use cl (MSVC) and %TEMP%
-    temp_dir = ENV["TEMP"]? || ENV["TMP"]? || "C:\\Windows\\Temp"
-    temp_exe = "#{temp_dir}\\ma_check_#{Process.pid}.exe"
-    compile_cmd = "cl /nologo /Fe:#{temp_exe} #{c_file} >nul 2>&1 && #{temp_exe} && del #{temp_exe} >nul 2>&1"
-    result = `cmd /c #{compile_cmd}`.strip
-  {% else %}
-    # Unix-like: use gcc and /tmp
-    compile_cmd = "gcc -o /tmp/ma_check_$$ #{c_file} 2>/dev/null && /tmp/ma_check_$$ && rm -f /tmp/ma_check_$$"
-    result = `sh -c '#{compile_cmd}'`.strip
-  {% end %}
+  begin
+    # Platform-specific compilation and execution
+    lines = {% if flag?(:win32) %}
+              # Windows: use cl (MSVC) and %TEMP%
+              temp_dir = ENV["TEMP"]? || ENV["TMP"]? || "C:\\Windows\\Temp"
+              temp_exe = "#{temp_dir}\\ma_check_#{Process.pid}.exe"
+              compile_cmd = "cl /nologo /Fe:#{temp_exe} #{c_file} >nul 2>&1 && #{temp_exe} && del #{temp_exe} >nul 2>&1"
+              `cmd /c #{compile_cmd}`.strip.split("\n")
+            {% else %}
+              # Unix-like: use gcc and /tmp
+              compile_cmd = "gcc -o /tmp/ma_check_$$ #{c_file} 2>/dev/null && /tmp/ma_check_$$ && rm -f /tmp/ma_check_$$"
+              `sh -c '#{compile_cmd}'`.strip.split("\n")
+            {% end %}
 
-  lines = result.split("\n")
+    # Parse the output: "key: value" format
+    # Only parse lines that contain miniaudio struct names
+    sizes = {} of String => Int32
+    lines.each do |line|
+      parts = line.split(":")
+      next unless parts.size == 2
+      key = parts[0].strip
+      # Only include ma_* keys, skip UInt32 and size_t
+      next unless key.starts_with?("ma_")
+      value = parts[1].strip.to_i
+      sizes[key] = value
+    end
 
-  # Parse the output: "key: value" format
-  # Only parse lines that contain miniaudio struct names
-  sizes = {} of String => Int32
-  lines.each do |line|
-    parts = line.split(":")
-    next unless parts.size == 2
-    key = parts[0].strip
-    # Only include ma_* keys, skip UInt32 and size_t
-    next unless key.starts_with?("ma_")
-    value = parts[1].strip.to_i
-    sizes[key] = value
+    sizes
+  rescue ex
+    # Fallback to conservative sizes if compilation fails
+    # This ensures builds don't break on unusual platforms
+    STDERR.puts "Warning: Could not detect miniaudio struct sizes, using defaults: #{ex.message}"
+    {
+      "ma_data_converter" => 4096,
+      "ma_context"        => 8192,
+      "ma_device"         => 8192,
+      "ma_mutex"          => 256,
+    }
   end
-
-  sizes
-rescue ex
-  # Fallback to conservative sizes if compilation fails
-  # This ensures builds don't break on unusual platforms
-  STDERR.puts "Warning: Could not detect miniaudio struct sizes, using defaults: #{ex.message}"
-  {
-    "ma_data_converter" => 4096,
-    "ma_context"        => 8192,
-    "ma_device"         => 8192,
-    "ma_mutex"          => 256,
-  }
 end
 
 sizes = get_miniaudio_sizes

--- a/src/raylib-cr/miniaudio_fix/ma_sizes.cr
+++ b/src/raylib-cr/miniaudio_fix/ma_sizes.cr
@@ -41,6 +41,18 @@ def get_miniaudio_sizes
       sizes[key] = value
     end
 
+    required_keys = ["ma_data_converter", "ma_context", "ma_device", "ma_mutex"]
+    missing = required_keys.select { |k| !sizes.has_key?(k) }
+    if missing.any?
+      STDERR.puts "Warning: Missing miniaudio struct sizes for: #{missing.join(", ")}. Raw output: #{lines.inspect}"
+      return {
+        "ma_data_converter" => 4096,
+        "ma_context"        => 8192,
+        "ma_device"         => 8192,
+        "ma_mutex"          => 256,
+      }
+    end
+
     sizes
   rescue ex
     # Fallback to conservative sizes if compilation fails

--- a/src/raylib-cr/miniaudio_fix/ma_sizes.cr
+++ b/src/raylib-cr/miniaudio_fix/ma_sizes.cr
@@ -14,18 +14,30 @@ def get_miniaudio_sizes
   # Path to the size-check C program
   c_file = "#{__DIR__}/../../../rsrc/miniaudiohelpers/miniaudio-size-check.c"
 
-  # Compile and run it, using a PID-specific temp file to avoid conflicts
-  compile_cmd = "gcc -o /tmp/ma_check_$$ #{c_file} 2>/dev/null && /tmp/ma_check_$$ && rm -f /tmp/ma_check_$$"
+  # Platform-specific compilation and execution
+  {% if flag?(:win32) %}
+    # Windows: use cl (MSVC) and %TEMP%
+    temp_dir = ENV["TEMP"]? || ENV["TMP"]? || "C:\\Windows\\Temp"
+    temp_exe = "#{temp_dir}\\ma_check_#{Process.pid}.exe"
+    compile_cmd = "cl /nologo /Fe:#{temp_exe} #{c_file} >nul 2>&1 && #{temp_exe} && del #{temp_exe} >nul 2>&1"
+    result = `cmd /c #{compile_cmd}`.strip
+  {% else %}
+    # Unix-like: use gcc and /tmp
+    compile_cmd = "gcc -o /tmp/ma_check_$$ #{c_file} 2>/dev/null && /tmp/ma_check_$$ && rm -f /tmp/ma_check_$$"
+    result = `sh -c '#{compile_cmd}'`.strip
+  {% end %}
 
-  result = `sh -c '#{compile_cmd}'`.strip
   lines = result.split("\n")
 
   # Parse the output: "key: value" format
+  # Only parse lines that contain miniaudio struct names
   sizes = {} of String => Int32
   lines.each do |line|
     parts = line.split(":")
     next unless parts.size == 2
     key = parts[0].strip
+    # Only include ma_* keys, skip UInt32 and size_t
+    next unless key.starts_with?("ma_")
     value = parts[1].strip.to_i
     sizes[key] = value
   end
@@ -34,7 +46,7 @@ def get_miniaudio_sizes
 rescue ex
   # Fallback to conservative sizes if compilation fails
   # This ensures builds don't break on unusual platforms
-  STDERR.puts "Warning: Could not detect miniaudio struct sizes, using defaults"
+  STDERR.puts "Warning: Could not detect miniaudio struct sizes, using defaults: #{ex.message}"
   {
     "ma_data_converter" => 4096,
     "ma_context"        => 8192,


### PR DESCRIPTION
This fixes the windows build process from failing with: 

```

Run New-Item -ItemType Directory -Force -Path bin

    Directory: D:\a\sands\sands

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----          10/28/2025  7:50 PM                bin
   Creating library C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.lib and object C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exp
Showing last frame. Use --error-trace for full trace.

In lib\raylib-cr\src\raylib-cr\audio.cr:7:6

 7 | {{ run "./miniaudio_fix/ma_sizes" }}
        ^--
Error: Error executing run (exit code: 1): ./miniaudio_fix/ma_sizes 


stderr:

    Unhandled exception: Missing hash key: "ma_data_converter" (KeyError)
      from C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exe +20727 in '??'
      from C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exe +247187 in '??'
      from C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exe +247068 in '??'
      from C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exe +17444 in '??'
      from C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exe +111117 in '??'
      from C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exe +112515 in '??'
      from C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-sands-sands-lib-raylib-cr-src-raylib-cr-miniaudio_fix-ma_sizes.cr\macro_run.exe +311548 in '??'
      from C:\Windows\System32\KERNEL32.DLL +190679 in 'BaseThreadInitThunk'
      from C:\Windows\SYSTEM32\ntdll.dll +574780 in 'RtlUserThreadStart'


```